### PR TITLE
Fix microphone permission bug: preserve entitlements during re-signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,10 @@ jobs:
           codesign --force --options runtime --timestamp --sign "$IDENTITY" \
             "$SPARKLE_PATH"
 
-          # Re-sign the main app
-          codesign --force --options runtime --timestamp --sign "$IDENTITY" "$APP_PATH"
+          # Re-sign the main app with entitlements preserved
+          codesign --force --options runtime --timestamp \
+            --entitlements VocaApp/VocaApp.entitlements \
+            --sign "$IDENTITY" "$APP_PATH"
 
           # Verify
           codesign --verify --deep --strict "$APP_PATH"

--- a/VocaApp.xcodeproj/project.pbxproj
+++ b/VocaApp.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zhengyishen.voca;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -364,7 +364,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zhengyishen.voca;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- Fix microphone permission bug by preserving entitlements during re-signing (ae1c635)
- Bump version to 1.2.8 for release (d36fc25)

## Problem
Issue #1: Release binaries have empty entitlements because the CI/CD re-signing step didn't include `--entitlements` flag, causing macOS to silently deny microphone access without showing a permission dialog.

## Root Cause
Line 97 in `.github/workflows/release.yml` re-signed the app WITHOUT the `--entitlements` flag, stripping the `com.apple.security.device.audio-input` entitlement that was embedded during the Xcode build.

## Solution
Added `--entitlements VocaApp/VocaApp.entitlements` to the codesign command at line 98. This ensures the microphone entitlement is preserved after notarization.

## Changes
1. **ae1c635**: Add `--entitlements` flag to release workflow re-signing step
2. **d36fc25**: Bump version from 1.2.5 to 1.2.8

## Testing
After merging and tagging v1.2.8, the released binary should:
- Have `com.apple.security.device.audio-input` entitlement preserved
- Show macOS microphone permission dialog on first use  
- Appear in System Settings > Privacy & Security > Microphone

Verify with: `codesign -d --entitlements - /Applications/Voca.app`

Fixes #1

Generated with Claude Code