### PR TITLE
Fix history audio playback with submenu and format fallback

### DIFF
--- a/Voca/Services/HistoryManager.swift
+++ b/Voca/Services/HistoryManager.swift
@@ -87,13 +87,64 @@ class HistoryManager {
             return
         }
 
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            print("Audio file not found: \(audioURL.path)")
+            return
+        }
+
         do {
             audioPlayer?.stop()
             audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
             audioPlayer?.play()
             print("Playing: \(audioURL.lastPathComponent)")
         } catch {
-            print("Failed to play audio: \(error)")
+            print("Direct playback failed: \(error), trying conversion...")
+            playWithConversion(audioURL)
+        }
+    }
+
+    private func playWithConversion(_ url: URL) {
+        do {
+            let audioFile = try AVAudioFile(forReading: url)
+            let format = audioFile.processingFormat
+            let frameCount = AVAudioFrameCount(audioFile.length)
+
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
+            try audioFile.read(into: buffer)
+
+            guard let int16Format = AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: format.sampleRate,
+                channels: format.channelCount,
+                interleaved: true
+            ) else { return }
+
+            guard let converter = AVAudioConverter(from: format, to: int16Format) else { return }
+            guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: int16Format, frameCapacity: frameCount) else { return }
+
+            var error: NSError?
+            converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+                outStatus.pointee = .haveData
+                return buffer
+            }
+
+            if let error = error {
+                print("Conversion failed: \(error)")
+                return
+            }
+
+            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("playback_\(UUID().uuidString).wav")
+            let outputFile = try AVAudioFile(forWriting: tempURL, settings: int16Format.settings)
+            try outputFile.write(from: outputBuffer)
+
+            audioPlayer = try AVAudioPlayer(contentsOf: tempURL)
+            audioPlayer?.play()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(frameCount) / format.sampleRate + 1.0) {
+                try? FileManager.default.removeItem(at: tempURL)
+            }
+        } catch {
+            print("Fallback playback failed: \(error)")
         }
     }
 

--- a/Voca/Views/StatusBarController.swift
+++ b/Voca/Views/StatusBarController.swift
@@ -262,6 +262,12 @@ class StatusBarController: NSObject {
         }
     }
 
+    @objc private func playHistoryAudio(_ sender: NSMenuItem) {
+        guard let dict = sender.representedObject as? [String: Any],
+              let index = dict["index"] as? Int else { return }
+        historyManager.playAudio(at: index)
+    }
+
     // MARK: - Update Checker
 
     @objc private func checkForUpdates() {
@@ -330,9 +336,10 @@ extension StatusBarController: NSMenuDelegate {
         menu.insertItem(header, at: insertIndex)
         insertIndex += 1
 
-        // Add history items - simple click to paste
+        // Add history items - with submenu for audio, simple click to paste otherwise
         for (i, historyItem) in historyItems.prefix(5).enumerated() {
             let preview = truncateToWidth(historyItem.text, maxWidth: 200)
+            let representedObject: [String: Any] = ["text": historyItem.text, "index": i]
 
             let item = NSMenuItem(
                 title: "  \(preview)",
@@ -340,8 +347,33 @@ extension StatusBarController: NSMenuDelegate {
                 keyEquivalent: ""
             )
             item.target = self
-            item.representedObject = historyItem.text
+            item.representedObject = representedObject
             item.tag = 201 + i
+
+            if historyItem.audioURL != nil {
+                let submenu = NSMenu()
+
+                let copyItem = NSMenuItem(
+                    title: NSLocalizedString("Copy to Clipboard", comment: ""),
+                    action: #selector(historyItemClicked(_:)),
+                    keyEquivalent: ""
+                )
+                copyItem.target = self
+                copyItem.representedObject = representedObject
+
+                let playItem = NSMenuItem(
+                    title: NSLocalizedString("Play Audio", comment: ""),
+                    action: #selector(playHistoryAudio(_:)),
+                    keyEquivalent: ""
+                )
+                playItem.target = self
+                playItem.representedObject = representedObject
+
+                submenu.addItem(copyItem)
+                submenu.addItem(playItem)
+                item.submenu = submenu
+                item.action = nil  // parent item opens submenu, not pastes
+            }
 
             menu.insertItem(item, at: insertIndex)
             insertIndex += 1


### PR DESCRIPTION
## Summary
- Add Play Audio / Copy to Clipboard submenu for history items with recordings
- Add file existence check before attempting playback
- Add Float32-to-Int16 WAV conversion fallback for AVAudioPlayer compatibility
- History items without audio retain existing click-to-paste behavior

## Test plan
- [ ] Record a transcription, open history menu, verify submenu appears
- [ ] Click "Play Audio" — verify recording plays back
- [ ] Click "Copy to Clipboard" — verify text is pasted
- [ ] History items without audio should paste on click (no submenu)
- [ ] xcodebuild build passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)