### PR TITLE
Fix history audio playback (NSSound + review fixes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,9 +202,20 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Save modified appcast.xml (we're on detached HEAD at the tag)
+          cp appcast.xml /tmp/appcast-updated.xml
+
+          # Fetch and checkout the actual main branch
+          git fetch origin main
+          git checkout origin/main -- appcast.xml || true
+          git checkout -B main origin/main
+
+          # Apply the updated appcast.xml onto main
+          cp /tmp/appcast-updated.xml appcast.xml
           git add appcast.xml
           git commit -m "Update appcast.xml for v${{ env.VERSION }}"
-          git push origin HEAD:main
+          git push origin main
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,8 +240,7 @@ jobs:
 
             ### Usage
 
-            - Double-tap ⌘ to start recording
-            - Release ⌘ to transcribe and auto-paste
+            - Hold ⌥ (Option) to record, release to transcribe and auto-paste
             - ⌃⌥V to paste from history
             - ESC to cancel during transcription
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,132 +2,71 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## What is Voca
+## Architecture (Do Not Refactor)
 
-Voca is a macOS menu bar app for on-device voice-to-text transcription. Users press a hotkey (default: hold Option ⌥), speak, and the transcribed text is auto-pasted at the cursor. All processing is local via CoreML — no audio leaves the device. Other hotkey presets include double-tap Option/Command/Control and hold combinations.
+3-layer parallel project:
 
-## Architecture (By Design — Do Not Refactor)
+1. **VocaApp.xcodeproj** — Xcode project for signing, entitlements, Sparkle framework linking, release builds. Entry: `VocaApp/main.swift`
+2. **Package.swift (VocaLib)** — SPM library wrapping all Swift source in `Voca/`. Used for `swift build` and AI editing. `swift build` will fail on Sparkle imports — use xcodebuild for full builds.
+3. **VoicePipeline.xcframework + libonnxruntime** — KMP-built ASR engine. Swift calls it via `import VoicePipeline` → `ASREngine`.
 
-Voca uses a **3-layer parallel project** architecture. This is intentional:
+**New Swift files must be added to BOTH Package.swift and VocaApp.xcodeproj.**
 
-```
-┌──────────────────────────────────┐
-│  VocaApp.xcodeproj               │  ← Xcode project: code signing, notarization, Sparkle
-│  (VocaApp/main.swift entry)      │     framework linking, release builds
-├──────────────────────────────────┤
-│  Package.swift (VocaLib)         │  ← SPM library: AI-friendly editing, `swift build`,
-│  (Voca/ source tree)             │     CI builds, all Swift source code lives here
-├──────────────────────────────────┤
-│  VoicePipeline.xcframework       │  ← Kotlin Multiplatform (KMP): ASR engine, model
-│  + libonnxruntime.1.17.0.dylib   │     inference via ONNX Runtime + CoreML
-└──────────────────────────────────┘
-```
-
-**Why parallel project?** Both Package.swift and VocaApp.xcodeproj reference the same `Voca/` source files. Package.swift is for `swift build` and AI-driven development. Xcode handles signing, entitlements, and framework linking (VoicePipeline.xcframework can't be linked via SPM alone). When adding new Swift files, they must be added to BOTH Package.swift and the Xcode project.
-
-**Why KMP at the bottom?** The VoicePipeline framework encapsulates all ASR logic in Kotlin, enabling future Android/cross-platform reuse. Swift talks to it via `ASREngine` (from `import VoicePipeline`).
-
-## Build & Development
+## Build
 
 ```bash
-# CLI build (for quick iteration, no signing)
-swift build
+# Full build (use this)
+xcodebuild build -project VocaApp.xcodeproj -scheme Voca -configuration Debug CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO
 
-# Xcode build (for signed builds, framework linking, release)
-xcodebuild build \
-  -project VocaApp.xcodeproj \
-  -scheme Voca \
-  -configuration Release \
-  CODE_SIGN_IDENTITY="-" \
-  CODE_SIGNING_REQUIRED=NO
-
-# Release: push a tag → CI/CD handles everything
-git tag v1.x.x && git push origin v1.x.x
+# Release: tag triggers CI
+git tag v1.x.x && git push upstream v1.x.x
 ```
 
-There are no tests in this project currently.
+No tests exist.
 
-## CI/CD Pipeline
+## CI/CD
 
-- **`.github/workflows/build.yml`** — Runs on push/PR to main. Builds for arm64 and x86_64 without signing.
-- **`.github/workflows/release.yml`** — Triggered by `v*` tags. Full pipeline: build → sign (Developer ID) → re-sign Sparkle binaries → notarize → create DMG → sign with Sparkle EdDSA → update appcast.xml → create GitHub Release → update Homebrew cask.
+- `build.yml` — push/PR to main, unsigned arm64+x86_64 build
+- `release.yml` — `v*` tag trigger: build → sign → re-sign Sparkle → notarize → DMG → EdDSA sign → appcast.xml commit → GitHub Release → Homebrew cask
 
-**Critical CI/CD detail:** The re-signing step must preserve entitlements. The `--entitlements VocaApp/VocaApp.entitlements` flag on the final `codesign` call is what grants microphone permission (`com.apple.security.device.audio-input`). Without it, the released app silently fails to access the mic.
+**Critical:** Final codesign MUST include `--entitlements VocaApp/VocaApp.entitlements` or mic permission is silently stripped.
 
-## Key Source Layout
+## Source Layout
 
 ```
-Voca/
-├── App/VoiceTranslatorApp.swift   # AppDelegate, main recording flow, paste logic
-├── Services/
-│   ├── AudioRecorder.swift        # AVAudioEngine recording, VAD-based speech segmentation
-│   ├── Transcriber.swift          # Bridges Swift ↔ KMP ASREngine, chunking, audio loading
-│   ├── ModelManager.swift         # Downloads/manages CoreML models from GitHub Releases
-│   ├── HotkeyMonitor.swift        # Global hotkey detection (hold/double-tap modes)
-│   ├── HistoryManager.swift       # Transcription history with audio playback
-│   ├── LicenseManager.swift       # Weekly rotating token validation (offline, no server)
-│   ├── AudioInputManager.swift    # System audio device selection
-│   └── UpdateChecker.swift        # Sparkle update delegate
-├── Views/
-│   ├── StatusBarController.swift  # Menu bar icon, menu, history display
-│   ├── RecordingOverlay.swift     # Floating waveform visualization
-│   ├── SettingsWindowController.swift  # Model selection, hotkey config, device picker
-│   ├── OnboardingWindowController.swift
-│   ├── LicenseWindowController.swift / LicenseView.swift
-│   └── AboutWindow.swift
-├── Settings/AppSettings.swift     # UserDefaults: model, hotkey, input device
-└── Resources/
-    ├── assets/                    # Bundled tokenizer files (BPE model, mel filterbank, vocab)
-    └── {en,zh-Hans,ja,ko,es}.lproj/  # Localization (5 languages)
-
-VocaApp/
-├── main.swift                     # Entry point: `VocaLib.VocaApp.main()`
-├── Info.plist                     # Bundle config, Sparkle feed URL, permissions
-└── VocaApp.entitlements           # audio-input entitlement (critical for mic access)
-
-Frameworks/
-├── VoicePipeline.xcframework      # KMP-built ASR engine
-└── libonnxruntime.1.17.0.dylib    # ONNX Runtime for model inference
+Voca/App/VoiceTranslatorApp.swift    — AppDelegate, recording lifecycle, auto-paste
+Voca/Services/AudioRecorder.swift    — AVAudioEngine, 16kHz mono, energy VAD (1.2s silence threshold)
+Voca/Services/Transcriber.swift      — Swift↔KMP bridge, audio chunking
+Voca/Services/ModelManager.swift     — Model download from GitHub Releases
+Voca/Services/HotkeyMonitor.swift    — Global hotkey (hold/double-tap modes)
+Voca/Services/HistoryManager.swift   — Last 10 transcriptions + audio files
+Voca/Services/LicenseManager.swift   — 7-day trial, weekly rotating tokens, offline
+Voca/Settings/AppSettings.swift      — UserDefaults: model, hotkey (default: hold ⌥), device
+Voca/Views/StatusBarController.swift — Menu bar, history display
+Voca/Views/RecordingOverlay.swift    — Waveform + live transcription preview
+VocaApp/VocaApp.entitlements         — com.apple.security.device.audio-input
 ```
 
 ## ASR Models
 
-Models are CoreML, downloaded on first run to `~/Library/Application Support/Voca/models/`:
+CoreML, downloaded to `~/Library/Application Support/Voca/models/`:
 
-| Model | Key | Languages | Notes |
-|-------|-----|-----------|-------|
-| SenseVoice | `sensevoice` | CN/EN/JA/KO/Cantonese | Default. Does NOT support hot words injection |
-| Whisper Turbo | `whisper` | 99+ languages | Fastest. Supports hot words via token injection |
-| Parakeet v2 | `parakeet` | English only | Best English accuracy. Supports hot words |
+| Model | Key | Languages | Hot Words |
+|-------|-----|-----------|-----------|
+| SenseVoice | `sensevoice` | CN/EN/JA/KO/Cantonese | No |
+| Whisper Turbo | `whisper` | 99+ | Yes (fastest) |
+| Parakeet v2 | `parakeet` | EN only | Yes (best EN accuracy) |
 
-Model files hosted at: `github.com/zhengyishen0/voca-app/releases/download/models-v1/`
+## Recording Flow
 
-## Recording & Transcription Flow
-
-1. **Hotkey detected** → `HotkeyMonitor` fires `onRecordStart`
-2. **Recording starts** → `AudioRecorder` captures 16kHz mono via `AVAudioEngine`, runs energy-based VAD
-3. **Incremental mode** → Speech segments (after 1.2s silence) sent to `Transcriber.transcribeSamples()` → live preview in overlay
-4. **Hotkey released** → Remaining buffer flushed, pending segments awaited
-5. **Post-processing** → Filler word removal (multi-language), punctuation normalization, CJK-aware formatting
-6. **Auto-paste** → Text copied to clipboard, `Cmd+V` simulated via `CGEvent` (Maccy-style implementation)
-
-## Auto-Update (Sparkle)
-
-- Feed URL: `https://voca.zhengyishen.com/appcast.xml` (configured in `VocaApp/Info.plist`)
-- EdDSA public key in Info.plist, private key in GitHub Secrets (`SPARKLE_PRIVATE_KEY`)
-- `appcast.xml` updated automatically by release CI — must be committed to main branch
-- Release workflow re-signs all Sparkle XPC services/binaries with the Developer ID certificate
-
-## Known Issues / Active Bugs
-
-1. **Audio cut-off** — Last segment of speech sometimes dropped. Likely related to the incremental transcription overlay feature (showing text while recording). Need to check if audio is not recorded vs not transcribed — each segment's audio is saved in `~/Library/Application Support/Voca/recordings/`.
-2. **Microphone permission in CI/CD** — Fixed in v1.2.8 by preserving entitlements during re-signing. The `--entitlements` flag was missing from the final codesign call in release.yml.
+Hotkey → `AudioRecorder` (16kHz mono, energy VAD) → speech segments on 1.2s silence → `Transcriber.transcribeSamples()` (incremental, live overlay) → hotkey release → flush remaining buffer → await pending segments → post-process (filler removal, CJK punctuation) → clipboard + CGEvent Cmd+V paste
 
 ## Conventions
 
-- **Singleton pattern** used for managers: `ModelManager.shared`, `HistoryManager.shared`, `LicenseManager.shared`, `AppSettings.shared`
-- **Notification-based communication** between components: `.modelChanged`, `.historyDidUpdate`, `.licenseStatusChanged`, `.updateAvailabilityChanged`
-- **Bundle ID**: `com.zhengyishen.voca`
-- **Minimum deployment**: macOS 13.0 (Ventura)
-- **Universal binary**: arm64 + x86_64
-- **Localization**: Use `NSLocalizedString()` — strings in 5 `.lproj` dirs
+- Singletons: `*.shared` (`ModelManager`, `HistoryManager`, `LicenseManager`, `AppSettings`)
+- Notifications for cross-component events: `.modelChanged`, `.historyDidUpdate`, `.licenseStatusChanged`
+- Bundle ID: `com.zhengyishen.voca`
+- macOS 13.0+, universal binary (arm64 + x86_64)
+- Localization: `NSLocalizedString()`, 5 languages (en, zh-Hans, ja, ko, es)
+- Sparkle feed: `https://voca.zhengyishen.com/appcast.xml`
+- Git remotes: `origin` = fork, `upstream` = `zhengyishen0/voca-app`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,133 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Voca
+
+Voca is a macOS menu bar app for on-device voice-to-text transcription. Users press a hotkey (default: hold Option ⌥), speak, and the transcribed text is auto-pasted at the cursor. All processing is local via CoreML — no audio leaves the device. Other hotkey presets include double-tap Option/Command/Control and hold combinations.
+
+## Architecture (By Design — Do Not Refactor)
+
+Voca uses a **3-layer parallel project** architecture. This is intentional:
+
+```
+┌──────────────────────────────────┐
+│  VocaApp.xcodeproj               │  ← Xcode project: code signing, notarization, Sparkle
+│  (VocaApp/main.swift entry)      │     framework linking, release builds
+├──────────────────────────────────┤
+│  Package.swift (VocaLib)         │  ← SPM library: AI-friendly editing, `swift build`,
+│  (Voca/ source tree)             │     CI builds, all Swift source code lives here
+├──────────────────────────────────┤
+│  VoicePipeline.xcframework       │  ← Kotlin Multiplatform (KMP): ASR engine, model
+│  + libonnxruntime.1.17.0.dylib   │     inference via ONNX Runtime + CoreML
+└──────────────────────────────────┘
+```
+
+**Why parallel project?** Both Package.swift and VocaApp.xcodeproj reference the same `Voca/` source files. Package.swift is for `swift build` and AI-driven development. Xcode handles signing, entitlements, and framework linking (VoicePipeline.xcframework can't be linked via SPM alone). When adding new Swift files, they must be added to BOTH Package.swift and the Xcode project.
+
+**Why KMP at the bottom?** The VoicePipeline framework encapsulates all ASR logic in Kotlin, enabling future Android/cross-platform reuse. Swift talks to it via `ASREngine` (from `import VoicePipeline`).
+
+## Build & Development
+
+```bash
+# CLI build (for quick iteration, no signing)
+swift build
+
+# Xcode build (for signed builds, framework linking, release)
+xcodebuild build \
+  -project VocaApp.xcodeproj \
+  -scheme Voca \
+  -configuration Release \
+  CODE_SIGN_IDENTITY="-" \
+  CODE_SIGNING_REQUIRED=NO
+
+# Release: push a tag → CI/CD handles everything
+git tag v1.x.x && git push origin v1.x.x
+```
+
+There are no tests in this project currently.
+
+## CI/CD Pipeline
+
+- **`.github/workflows/build.yml`** — Runs on push/PR to main. Builds for arm64 and x86_64 without signing.
+- **`.github/workflows/release.yml`** — Triggered by `v*` tags. Full pipeline: build → sign (Developer ID) → re-sign Sparkle binaries → notarize → create DMG → sign with Sparkle EdDSA → update appcast.xml → create GitHub Release → update Homebrew cask.
+
+**Critical CI/CD detail:** The re-signing step must preserve entitlements. The `--entitlements VocaApp/VocaApp.entitlements` flag on the final `codesign` call is what grants microphone permission (`com.apple.security.device.audio-input`). Without it, the released app silently fails to access the mic.
+
+## Key Source Layout
+
+```
+Voca/
+├── App/VoiceTranslatorApp.swift   # AppDelegate, main recording flow, paste logic
+├── Services/
+│   ├── AudioRecorder.swift        # AVAudioEngine recording, VAD-based speech segmentation
+│   ├── Transcriber.swift          # Bridges Swift ↔ KMP ASREngine, chunking, audio loading
+│   ├── ModelManager.swift         # Downloads/manages CoreML models from GitHub Releases
+│   ├── HotkeyMonitor.swift        # Global hotkey detection (hold/double-tap modes)
+│   ├── HistoryManager.swift       # Transcription history with audio playback
+│   ├── LicenseManager.swift       # Weekly rotating token validation (offline, no server)
+│   ├── AudioInputManager.swift    # System audio device selection
+│   └── UpdateChecker.swift        # Sparkle update delegate
+├── Views/
+│   ├── StatusBarController.swift  # Menu bar icon, menu, history display
+│   ├── RecordingOverlay.swift     # Floating waveform visualization
+│   ├── SettingsWindowController.swift  # Model selection, hotkey config, device picker
+│   ├── OnboardingWindowController.swift
+│   ├── LicenseWindowController.swift / LicenseView.swift
+│   └── AboutWindow.swift
+├── Settings/AppSettings.swift     # UserDefaults: model, hotkey, input device
+└── Resources/
+    ├── assets/                    # Bundled tokenizer files (BPE model, mel filterbank, vocab)
+    └── {en,zh-Hans,ja,ko,es}.lproj/  # Localization (5 languages)
+
+VocaApp/
+├── main.swift                     # Entry point: `VocaLib.VocaApp.main()`
+├── Info.plist                     # Bundle config, Sparkle feed URL, permissions
+└── VocaApp.entitlements           # audio-input entitlement (critical for mic access)
+
+Frameworks/
+├── VoicePipeline.xcframework      # KMP-built ASR engine
+└── libonnxruntime.1.17.0.dylib    # ONNX Runtime for model inference
+```
+
+## ASR Models
+
+Models are CoreML, downloaded on first run to `~/Library/Application Support/Voca/models/`:
+
+| Model | Key | Languages | Notes |
+|-------|-----|-----------|-------|
+| SenseVoice | `sensevoice` | CN/EN/JA/KO/Cantonese | Default. Does NOT support hot words injection |
+| Whisper Turbo | `whisper` | 99+ languages | Fastest. Supports hot words via token injection |
+| Parakeet v2 | `parakeet` | English only | Best English accuracy. Supports hot words |
+
+Model files hosted at: `github.com/zhengyishen0/voca-app/releases/download/models-v1/`
+
+## Recording & Transcription Flow
+
+1. **Hotkey detected** → `HotkeyMonitor` fires `onRecordStart`
+2. **Recording starts** → `AudioRecorder` captures 16kHz mono via `AVAudioEngine`, runs energy-based VAD
+3. **Incremental mode** → Speech segments (after 1.2s silence) sent to `Transcriber.transcribeSamples()` → live preview in overlay
+4. **Hotkey released** → Remaining buffer flushed, pending segments awaited
+5. **Post-processing** → Filler word removal (multi-language), punctuation normalization, CJK-aware formatting
+6. **Auto-paste** → Text copied to clipboard, `Cmd+V` simulated via `CGEvent` (Maccy-style implementation)
+
+## Auto-Update (Sparkle)
+
+- Feed URL: `https://voca.zhengyishen.com/appcast.xml` (configured in `VocaApp/Info.plist`)
+- EdDSA public key in Info.plist, private key in GitHub Secrets (`SPARKLE_PRIVATE_KEY`)
+- `appcast.xml` updated automatically by release CI — must be committed to main branch
+- Release workflow re-signs all Sparkle XPC services/binaries with the Developer ID certificate
+
+## Known Issues / Active Bugs
+
+1. **Audio cut-off** — Last segment of speech sometimes dropped. Likely related to the incremental transcription overlay feature (showing text while recording). Need to check if audio is not recorded vs not transcribed — each segment's audio is saved in `~/Library/Application Support/Voca/recordings/`.
+2. **Microphone permission in CI/CD** — Fixed in v1.2.8 by preserving entitlements during re-signing. The `--entitlements` flag was missing from the final codesign call in release.yml.
+
+## Conventions
+
+- **Singleton pattern** used for managers: `ModelManager.shared`, `HistoryManager.shared`, `LicenseManager.shared`, `AppSettings.shared`
+- **Notification-based communication** between components: `.modelChanged`, `.historyDidUpdate`, `.licenseStatusChanged`, `.updateAvailabilityChanged`
+- **Bundle ID**: `com.zhengyishen.voca`
+- **Minimum deployment**: macOS 13.0 (Ventura)
+- **Universal binary**: arm64 + x86_64
+- **Localization**: Use `NSLocalizedString()` — strings in 5 `.lproj` dirs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,4 +69,4 @@ Hotkey → `AudioRecorder` (16kHz mono, energy VAD) → speech segments on 1.2s 
 - macOS 13.0+, universal binary (arm64 + x86_64)
 - Localization: `NSLocalizedString()`, 5 languages (en, zh-Hans, ja, ko, es)
 - Sparkle feed: `https://voca.zhengyishen.com/appcast.xml`
-- Git remotes: `origin` = `zhengyishen0/voca-app`, `fork` = `alanxurox/voca-app` (legacy)
+- Repo: `zhengyishen0/voca-app`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,10 @@ No tests exist.
 - **Never commit directly to main.** Use feature branches + PRs.
 - Release tags go on main after PR merge.
 - **Before tagging a release:**
-  1. `xcodebuild build` must pass (catches syntax/type errors)
+  1. PR must pass CI build checks (GitHub runs `xcodebuild` on `macos-14` runners)
   2. Launch the app locally and manually verify the change works
-  3. PR must be reviewed/merged before tagging
-- No "build and tag in the same session" — build, test, then tag separately.
+  3. PR must be merged before tagging
+- No "build and tag in the same session" — verify CI green, manual test, then tag.
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,4 +69,4 @@ Hotkey → `AudioRecorder` (16kHz mono, energy VAD) → speech segments on 1.2s 
 - macOS 13.0+, universal binary (arm64 + x86_64)
 - Localization: `NSLocalizedString()`, 5 languages (en, zh-Hans, ja, ko, es)
 - Sparkle feed: `https://voca.zhengyishen.com/appcast.xml`
-- Git remotes: `origin` = fork, `upstream` = `zhengyishen0/voca-app`
+- Git remotes: `origin` = `zhengyishen0/voca-app`, `fork` = `alanxurox/voca-app` (legacy)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,12 @@ xcodebuild build -project VocaApp.xcodeproj -scheme Voca -configuration Debug CO
 git tag v1.x.x && git push origin v1.x.x
 ```
 
-No tests exist.
+SPM test target in `Sources/VocaTestable/` + `Tests/VocaTests/` — 22 tests covering VAD logic, text post-processing, and audio utils. Tests do NOT cover VoicePipeline (KMP binary), Sparkle, or hardware audio.
+
+```bash
+# Run tests (swift test fails on Sparkle — use xcrun directly)
+swift build --target VocaTests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest
+```
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,22 +22,53 @@ xcodebuild build -project VocaApp.xcodeproj -scheme Voca -configuration Debug CO
 git tag v1.x.x && git push origin v1.x.x
 ```
 
-SPM test target in `Sources/VocaTestable/` + `Tests/VocaTests/` — 22 tests covering VAD logic, text post-processing, and audio utils. Tests do NOT cover VoicePipeline (KMP binary), Sparkle, or hardware audio.
+SPM test target in `Sources/VocaTestable/` + `Tests/VocaTests/` — 30 tests covering VAD logic, text post-processing, audio playback, and WAV I/O. Tests do NOT cover VoicePipeline (KMP binary), Sparkle, or hardware audio.
 
 ```bash
 # Run tests (swift test fails on Sparkle — use xcrun directly)
-swift build --target VocaTests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest
+swift build --build-tests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest
 ```
 
 ## Workflow
 
 - **Never commit directly to main.** Use feature branches + PRs.
 - Release tags go on main after PR merge.
+- **Before merging a PR:**
+  1. Run SPM tests: `swift build --build-tests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest`
+  2. Run code-reviewer agent (or manual review) for non-trivial changes
+  3. User must explicitly approve the merge — AI must never auto-merge
 - **Before tagging a release:**
   1. PR must pass CI build checks (GitHub runs `xcodebuild` on `macos-14` runners)
   2. Launch the app locally and manually verify the change works
   3. PR must be merged before tagging
 - No "build and tag in the same session" — verify CI green, manual test, then tag.
+
+## AI Development Guidelines
+
+### Review Gates (Required Before Merge)
+- SPM test suite must pass (30+ tests covering VAD, text processing, audio playback)
+- Code review via `code-reviewer` agent for any non-trivial changes
+- User explicit approval before merging to main
+- For release PRs: also require manual app testing by user
+
+### CLI Testing Philosophy
+The SPM architecture (VocaTestable + VocaTests) exists so AI can verify features from CLI without:
+- Launching the full Xcode app
+- Dealing with TCC permission resets (accessibility, microphone)
+- Manual GUI interaction
+
+Test command: `swift build --build-tests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest`
+
+### Available Expert Agents
+These agents are available via oh-my-claudecode for specialized review:
+- `code-reviewer`: Comprehensive code review across concerns
+- `security-reviewer`: Vulnerability detection, auth/crypto checks
+- `quality-reviewer`: Logic defects, anti-patterns, SOLID principles
+- `performance-reviewer`: Hotspots, complexity analysis
+- `build-fixer`: Build/type errors with minimal changes
+- `test-engineer`: Test strategy, coverage, flaky test hardening
+
+Always run code-reviewer before merging feature PRs. Use security-reviewer for changes touching auth, licensing, or permissions.
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,21 +35,15 @@ swift build --build-tests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPa
 - Release tags go on main after PR merge.
 - **Before merging a PR:**
   1. Run SPM tests: `swift build --build-tests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest`
-  2. Run code-reviewer agent (or manual review) for non-trivial changes
-  3. User must explicitly approve the merge — AI must never auto-merge
+  2. Code review (manual or automated) for non-trivial changes
+  3. Explicit approval before merge — AI tools must never auto-merge
 - **Before tagging a release:**
   1. PR must pass CI build checks (GitHub runs `xcodebuild` on `macos-14` runners)
   2. Launch the app locally and manually verify the change works
   3. PR must be merged before tagging
 - No "build and tag in the same session" — verify CI green, manual test, then tag.
 
-## AI Development Guidelines
-
-### Review Gates (Required Before Merge)
-- SPM test suite must pass (30+ tests covering VAD, text processing, audio playback)
-- Code review via `code-reviewer` agent for any non-trivial changes
-- User explicit approval before merging to main
-- For release PRs: also require manual app testing by user
+## Testing
 
 ### CLI Testing Philosophy
 The SPM architecture (VocaTestable + VocaTests) exists so AI can verify features from CLI without:
@@ -75,16 +69,6 @@ print("\(f.lastPathComponent) — \(p.duration)s"); p.play(); Thread.sleep(forTi
 '
 ```
 
-### Available Expert Agents
-These agents are available via oh-my-claudecode for specialized review:
-- `code-reviewer`: Comprehensive code review across concerns
-- `security-reviewer`: Vulnerability detection, auth/crypto checks
-- `quality-reviewer`: Logic defects, anti-patterns, SOLID principles
-- `performance-reviewer`: Hotspots, complexity analysis
-- `build-fixer`: Build/type errors with minimal changes
-- `test-engineer`: Test strategy, coverage, flaky test hardening
-
-Always run code-reviewer before merging feature PRs. Use security-reviewer for changes touching auth, licensing, or permissions.
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 xcodebuild build -project VocaApp.xcodeproj -scheme Voca -configuration Debug CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO
 
 # Release: tag triggers CI
-git tag v1.x.x && git push upstream v1.x.x
+git tag v1.x.x && git push origin v1.x.x
 ```
 
 No tests exist.
+
+## Workflow
+
+- **Never commit directly to main.** Use feature branches + PRs.
+- Release tags go on main after PR merge.
 
 ## CI/CD
 
@@ -70,3 +75,9 @@ Hotkey → `AudioRecorder` (16kHz mono, energy VAD) → speech segments on 1.2s 
 - Localization: `NSLocalizedString()`, 5 languages (en, zh-Hans, ja, ko, es)
 - Sparkle feed: `https://voca.zhengyishen.com/appcast.xml`
 - Repo: `zhengyishen0/voca-app`
+
+## Known Gotchas
+
+- **TCC is per-signature**: Re-signing the binary (e.g., adding `--entitlements`) invalidates macOS accessibility permissions. Use `AXIsProcessTrustedWithOptions(prompt: true)` to re-prompt correctly, not just opening System Settings.
+- **Model switching is a no-op**: `Transcriber.setModel()` does nothing — KMP `ASREngine` has no model selection API. Always uses the model loaded at startup.
+- **`swift build` fails on Sparkle imports**: Expected. Use `xcodebuild` for full builds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,22 @@ The SPM architecture (VocaTestable + VocaTests) exists so AI can verify features
 
 Test command: `swift build --build-tests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest`
 
+**Ad-hoc audio playback test** (plays latest recording for N seconds):
+```bash
+swift -e '
+import AVFoundation; import Foundation
+let dir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support/Voca/recordings")
+let files = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.contentModificationDateKey])
+    .sorted { a, b in
+        let ad = (try? a.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+        let bd = (try? b.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+        return ad > bd }
+guard let f = files.first else { print("No recordings"); exit(1) }
+let p = try AVAudioPlayer(contentsOf: f)
+print("\(f.lastPathComponent) — \(p.duration)s"); p.play(); Thread.sleep(forTimeInterval: 10); p.stop()
+'
+```
+
 ### Available Expert Agents
 These agents are available via oh-my-claudecode for specialized review:
 - `code-reviewer`: Comprehensive code review across concerns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,11 @@ No tests exist.
 
 - **Never commit directly to main.** Use feature branches + PRs.
 - Release tags go on main after PR merge.
+- **Before tagging a release:**
+  1. `xcodebuild build` must pass (catches syntax/type errors)
+  2. Launch the app locally and manually verify the change works
+  3. PR must be reviewed/merged before tagging
+- No "build and tag in the same session" — build, test, then tag separately.
 
 ## CI/CD
 

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ let package = Package(
     name: "Voca",
     platforms: [.macOS(.v13)],
     products: [
-        .library(name: "VocaLib", targets: ["VocaLib"])
+        .library(name: "VocaLib", targets: ["VocaLib"]),
+        .library(name: "VocaTestable", targets: ["VocaTestable"])
     ],
     targets: [
         .binaryTarget(
@@ -17,6 +18,17 @@ let package = Package(
             dependencies: ["VoicePipeline"],
             path: "Voca",
             resources: [.copy("Resources")]
+        ),
+        .target(
+            name: "VocaTestable",
+            dependencies: [],
+            path: "Sources/VocaTestable"
+        ),
+        .testTarget(
+            name: "VocaTests",
+            dependencies: ["VocaTestable"],
+            path: "Tests/VocaTests",
+            resources: [.copy("Fixtures")]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -97,6 +97,41 @@ Voca includes multiple ASR models optimized for different use cases:
 
 Voca processes all audio locally on your Mac using CoreML. No audio data is ever sent to external servers. Your voice stays on your device.
 
+## Development
+
+### Roadmap
+
+**Audio Pipeline**
+- Rollback audio chunking to pre-live-streaming version (bigger chunks = more accurate)
+- Fix last chunk dropout bug (flush threshold fixed, needs verification)
+- Investigate optimal chunk size vs accuracy tradeoff
+- Consider disabling live streaming preview entirely (accuracy tradeoff)
+- Add macOS mic mode awareness (Voice Isolation may degrade transcription)
+
+**ASR Models**
+- Compare model accuracy: test same audio against Parakeet, Whisper Turbo, SenseVoice
+- Research external accuracy benchmarks (Doubao, WeChat, OpenAI Whisper API)
+- Test new ASR models: Qwen 3.5 transcription, HuggingFace models
+- Explore small model post-processing for accuracy
+
+**Testing**
+- Add SPM-based automated testing (VAD logic, text post-processing, audio chunking)
+- Build VAD parameter comparison suite
+
+**Features**
+- Fix recording playback in History
+- Start new features after major bugs fixed
+
+### Building
+
+```bash
+# Debug build
+xcodebuild build -project VocaApp.xcodeproj -scheme Voca -configuration Debug CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO
+
+# Run tests (swift test fails on Sparkle — use xcrun directly)
+swift build --target VocaTests && xcrun xctest .build/arm64-apple-macosx/debug/VocaPackageTests.xctest
+```
+
 ## License
 
 MIT License - Free and open source

--- a/Sources/VocaTestable/AudioUtils.swift
+++ b/Sources/VocaTestable/AudioUtils.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Generate a sine wave for testing
+public func generateSineWave(
+    frequency: Float,
+    duration: Double,
+    sampleRate: Int = 16000,
+    amplitude: Float = 0.5
+) -> [Float] {
+    let sampleCount = Int(duration * Double(sampleRate))
+    return (0..<sampleCount).map { i in
+        amplitude * sin(2.0 * Float.pi * frequency * Float(i) / Float(sampleRate))
+    }
+}
+
+/// Generate silence
+public func generateSilence(duration: Double, sampleRate: Int = 16000) -> [Float] {
+    let sampleCount = Int(duration * Double(sampleRate))
+    return [Float](repeating: 0, count: sampleCount)
+}
+
+/// Generate noise
+public func generateNoise(duration: Double, sampleRate: Int = 16000, amplitude: Float = 0.001) -> [Float] {
+    let sampleCount = Int(duration * Double(sampleRate))
+    return (0..<sampleCount).map { _ in Float.random(in: -amplitude...amplitude) }
+}
+
+/// Concatenate multiple audio segments
+public func concatenateAudio(_ segments: [[Float]]) -> [Float] {
+    segments.flatMap { $0 }
+}

--- a/Sources/VocaTestable/AudioUtils.swift
+++ b/Sources/VocaTestable/AudioUtils.swift
@@ -56,7 +56,13 @@ public func testPlayback(url: URL) -> (success: Bool, error: String?) {
             }
 
             var convError: NSError?
+            var inputConsumed = false
             converter.convert(to: outputBuffer, error: &convError) { _, outStatus in
+                if inputConsumed {
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+                inputConsumed = true
                 outStatus.pointee = .haveData
                 return buffer
             }

--- a/Sources/VocaTestable/AudioUtils.swift
+++ b/Sources/VocaTestable/AudioUtils.swift
@@ -1,4 +1,81 @@
+import AVFoundation
 import Foundation
+
+/// Write Float32 samples to a WAV file (matches AudioRecorder output format)
+public func writeWAV(samples: [Float], sampleRate: Int = 16000, to url: URL) throws {
+    guard let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: Double(sampleRate),
+        channels: 1,
+        interleaved: false
+    ) else { throw NSError(domain: "AudioUtils", code: 1, userInfo: [NSLocalizedDescriptionKey: "Cannot create format"]) }
+
+    let file = try AVAudioFile(forWriting: url, settings: format.settings, commonFormat: .pcmFormatFloat32, interleaved: false)
+    guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count)) else {
+        throw NSError(domain: "AudioUtils", code: 2, userInfo: [NSLocalizedDescriptionKey: "Cannot create buffer"])
+    }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    samples.withUnsafeBufferPointer { ptr in
+        buffer.floatChannelData![0].update(from: ptr.baseAddress!, count: samples.count)
+    }
+    try file.write(from: buffer)
+}
+
+/// Test playback of a WAV file. Returns (success, errorMessage).
+public func testPlayback(url: URL) -> (success: Bool, error: String?) {
+    guard FileManager.default.fileExists(atPath: url.path) else {
+        return (false, "File not found: \(url.path)")
+    }
+    // Verify readable as audio
+    do {
+        let audioFile = try AVAudioFile(forReading: url)
+        let format = audioFile.processingFormat
+        let frames = audioFile.length
+        guard frames > 0 else { return (false, "Empty audio file") }
+
+        // Test AVAudioPlayer creation (same code path as HistoryManager.playAudio)
+        let player = try AVAudioPlayer(contentsOf: url)
+        guard player.duration > 0 else { return (false, "Player reports 0 duration") }
+
+        return (true, nil)
+    } catch {
+        // Try Float32→Int16 conversion fallback (same as HistoryManager.playWithConversion)
+        do {
+            let audioFile = try AVAudioFile(forReading: url)
+            let format = audioFile.processingFormat
+            let frameCount = AVAudioFrameCount(audioFile.length)
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+                return (false, "Cannot create read buffer")
+            }
+            try audioFile.read(into: buffer)
+
+            guard let int16Format = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: format.sampleRate, channels: format.channelCount, interleaved: true),
+                  let converter = AVAudioConverter(from: format, to: int16Format),
+                  let outputBuffer = AVAudioPCMBuffer(pcmFormat: int16Format, frameCapacity: frameCount) else {
+                return (false, "Cannot create converter for fallback")
+            }
+
+            var convError: NSError?
+            converter.convert(to: outputBuffer, error: &convError) { _, outStatus in
+                outStatus.pointee = .haveData
+                return buffer
+            }
+            if let convError = convError { return (false, "Conversion failed: \(convError)") }
+
+            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_\(UUID().uuidString).wav")
+            let outputFile = try AVAudioFile(forWriting: tempURL, settings: int16Format.settings)
+            try outputFile.write(from: outputBuffer)
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            let player = try AVAudioPlayer(contentsOf: tempURL)
+            guard player.duration > 0 else { return (false, "Converted player reports 0 duration") }
+
+            return (true, nil)
+        } catch {
+            return (false, "Both direct and fallback failed: \(error)")
+        }
+    }
+}
 
 /// Generate a sine wave for testing
 public func generateSineWave(

--- a/Sources/VocaTestable/TextPostProcessing.swift
+++ b/Sources/VocaTestable/TextPostProcessing.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Post-process transcribed text: filler removal and formatting.
+/// Extracted from AppDelegate.postProcessText in VoiceTranslatorApp.swift.
+public func postProcessText(_ text: String) -> String {
+    var result = text
+
+    // 1. Remove basic filler words (multiple languages)
+    // English: um, uh, er, ah, hmm
+    // Chinese: 呃, 嗯, 啊, 那个
+    // Japanese: えーと, あの, えー
+    // Korean: 음, 어
+    let fillerWords = ["um", "uh", "er", "ah", "hmm", "呃", "嗯", "啊", "那个", "えーと", "あの", "えー", "음", "어"]
+    for filler in fillerWords {
+        // Remove filler surrounded by spaces
+        result = result.replacingOccurrences(of: " \(filler) ", with: " ", options: .caseInsensitive)
+        // Remove filler at start
+        result = result.replacingOccurrences(of: "^\(filler) ", with: "", options: [.caseInsensitive, .regularExpression])
+        // Remove filler followed by comma
+        result = result.replacingOccurrences(of: " \(filler),", with: ",", options: .caseInsensitive)
+    }
+
+    // 2. Fix spacing and punctuation
+    result = result.replacingOccurrences(of: "  +", with: " ", options: .regularExpression)  // Multiple spaces
+    result = result.replacingOccurrences(of: " ,", with: ",")  // Space before comma
+    result = result.replacingOccurrences(of: " \\.", with: ".", options: .regularExpression)  // Space before period
+
+    // 3. Clean up duplicate/mixed punctuation
+    // Detect if text is primarily Chinese (contains CJK characters)
+    let isChinese = result.range(of: "\\p{Han}", options: .regularExpression) != nil
+
+    if isChinese {
+        // Chinese text: normalize to Chinese punctuation
+        result = result.replacingOccurrences(of: "[。.\\s]*[。.][。.\\s]*", with: "。", options: .regularExpression)
+        result = result.replacingOccurrences(of: "[，,\\s]*[，,][，,\\s]*", with: "，", options: .regularExpression)
+        result = result.replacingOccurrences(of: "[？?\\s]*[？?][？?\\s]*", with: "？", options: .regularExpression)
+        result = result.replacingOccurrences(of: "[！!\\s]*[！!][！!\\s]*", with: "！", options: .regularExpression)
+        // Remove comma before period: ，。 → 。
+        result = result.replacingOccurrences(of: "，。", with: "。")
+        result = result.replacingOccurrences(of: "。，", with: "。")
+        // Remove period after question/exclamation
+        result = result.replacingOccurrences(of: "？[。.]", with: "？", options: .regularExpression)
+        result = result.replacingOccurrences(of: "！[。.]", with: "！", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\?[。.]", with: "？", options: .regularExpression)
+        result = result.replacingOccurrences(of: "![。.]", with: "！", options: .regularExpression)
+    } else {
+        // English text: normalize to English punctuation
+        result = result.replacingOccurrences(of: "[.\\s]*\\.[.\\s]*", with: ". ", options: .regularExpression)
+        result = result.replacingOccurrences(of: ",+", with: ",", options: .regularExpression)
+        result = result.replacingOccurrences(of: ",\\s*\\.", with: ".", options: .regularExpression)  // Comma before period → period
+        result = result.replacingOccurrences(of: "\\.\\s*,", with: ",", options: .regularExpression)  // Period before comma → comma
+        result = result.replacingOccurrences(of: "\\?+", with: "?", options: .regularExpression)
+        result = result.replacingOccurrences(of: "!+", with: "!", options: .regularExpression)
+    }
+
+    // Clean up any remaining multiple spaces
+    result = result.replacingOccurrences(of: "\\s{2,}", with: " ", options: .regularExpression)
+
+    // 4. Capitalize first letter (for English text)
+    if let first = result.first {
+        result = first.uppercased() + result.dropFirst()
+    }
+
+    return result.trimmingCharacters(in: .whitespaces)
+}

--- a/Sources/VocaTestable/VADLogic.swift
+++ b/Sources/VocaTestable/VADLogic.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// VAD configuration parameters
+public struct VADConfig {
+    public let silenceThreshold: Float    // RMS threshold for silence
+    public let silenceDuration: Double     // Seconds of silence to trigger segment end
+    public let minSpeechDuration: Double   // Minimum speech duration to process
+    public let sampleRate: Int
+
+    public init(
+        silenceThreshold: Float = 0.02,
+        silenceDuration: Double = 1.2,
+        minSpeechDuration: Double = 1.0,
+        sampleRate: Int = 16000
+    ) {
+        self.silenceThreshold = silenceThreshold
+        self.silenceDuration = silenceDuration
+        self.minSpeechDuration = minSpeechDuration
+        self.sampleRate = sampleRate
+    }
+}
+
+/// Result of VAD segmentation
+public struct VADSegment {
+    public let samples: [Float]
+    public let startSample: Int
+    public let endSample: Int
+
+    public var duration: Double {
+        Double(samples.count) / 16000.0
+    }
+}
+
+/// Calculate RMS energy of a sample buffer
+public func calculateRMS(_ samples: [Float]) -> Float {
+    guard !samples.isEmpty else { return 0 }
+    let sumSquares = samples.reduce(Float(0)) { $0 + $1 * $1 }
+    return sqrt(sumSquares / Float(samples.count))
+}
+
+/// Split audio into speech segments using energy-based VAD
+/// This is the testable version of Transcriber.splitAudioByVAD
+public func splitAudioByVAD(
+    _ samples: [Float],
+    config: VADConfig = VADConfig(),
+    maxChunkSeconds: Int = 60
+) -> [VADSegment] {
+    let sampleRate = config.sampleRate
+    let maxChunkSamples = maxChunkSeconds * sampleRate
+    let minSilenceSamples = Int(0.3 * Double(sampleRate))
+    let minChunkSamples = sampleRate  // 1 second minimum
+    let windowSize = Int(0.025 * Double(sampleRate))  // 25ms
+    let energyThreshold = config.silenceThreshold
+
+    var segments: [VADSegment] = []
+    var currentChunkStart = 0
+    var silenceStart: Int? = nil
+
+    var i = 0
+    while i < samples.count {
+        let windowEnd = min(i + windowSize, samples.count)
+        var energy: Float = 0
+        for j in i..<windowEnd {
+            energy += samples[j] * samples[j]
+        }
+        energy /= Float(windowEnd - i)
+
+        let isSilence = energy < energyThreshold
+
+        if isSilence {
+            if silenceStart == nil {
+                silenceStart = i
+            }
+        } else {
+            if let start = silenceStart {
+                let silenceLength = i - start
+                let chunkLength = i - currentChunkStart
+
+                if silenceLength >= minSilenceSamples && chunkLength >= minChunkSamples {
+                    let splitPoint = start + silenceLength / 2
+                    let chunk = Array(samples[currentChunkStart..<splitPoint])
+                    segments.append(VADSegment(
+                        samples: chunk,
+                        startSample: currentChunkStart,
+                        endSample: splitPoint
+                    ))
+                    currentChunkStart = splitPoint
+                }
+            }
+            silenceStart = nil
+        }
+
+        let chunkLength = i - currentChunkStart
+        if chunkLength >= maxChunkSamples {
+            let chunk = Array(samples[currentChunkStart..<i])
+            segments.append(VADSegment(
+                samples: chunk,
+                startSample: currentChunkStart,
+                endSample: i
+            ))
+            currentChunkStart = i
+            silenceStart = nil
+        }
+
+        i += windowSize
+    }
+
+    if currentChunkStart < samples.count {
+        let chunk = Array(samples[currentChunkStart...])
+        if chunk.count >= minChunkSamples / 2 {
+            segments.append(VADSegment(
+                samples: chunk,
+                startSample: currentChunkStart,
+                endSample: samples.count
+            ))
+        }
+    }
+
+    return segments
+}

--- a/Tests/VocaTests/AudioPlaybackTests.swift
+++ b/Tests/VocaTests/AudioPlaybackTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import VocaTestable
+
+final class AudioPlaybackTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("VocaTests_\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - WAV Write/Read Round-Trip
+
+    func testWriteAndReadWAV() throws {
+        let samples = generateSineWave(frequency: 440, duration: 1.0, amplitude: 0.3)
+        let url = tempDir.appendingPathComponent("test.wav")
+
+        try writeWAV(samples: samples, to: url)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let size = attrs[.size] as? Int ?? 0
+        XCTAssertGreaterThan(size, 0, "WAV file should not be empty")
+    }
+
+    func testWAVFormatIsFloat32Mono16kHz() throws {
+        let samples = generateSineWave(frequency: 440, duration: 0.5)
+        let url = tempDir.appendingPathComponent("format_test.wav")
+        try writeWAV(samples: samples, to: url)
+
+        let result = testPlayback(url: url)
+        XCTAssertTrue(result.success, "Playback should succeed: \(result.error ?? "")")
+    }
+
+    // MARK: - Playback (simulates HistoryManager.playAudio code path)
+
+    func testDirectPlaybackFloat32WAV() throws {
+        // This tests the exact same code path as HistoryManager.playAudio()
+        // AudioRecorder writes Float32 mono 16kHz → HistoryManager copies to recordings/ → AVAudioPlayer
+        let samples = generateSineWave(frequency: 440, duration: 2.0, amplitude: 0.3)
+        let url = tempDir.appendingPathComponent("playback_test.wav")
+        try writeWAV(samples: samples, to: url)
+
+        let result = testPlayback(url: url)
+        XCTAssertTrue(result.success, "Direct Float32 playback should work: \(result.error ?? "")")
+    }
+
+    func testPlaybackWithQuietAudio() throws {
+        // Very quiet audio should still be playable
+        let samples = generateSineWave(frequency: 440, duration: 1.0, amplitude: 0.01)
+        let url = tempDir.appendingPathComponent("quiet_test.wav")
+        try writeWAV(samples: samples, to: url)
+
+        let result = testPlayback(url: url)
+        XCTAssertTrue(result.success, "Quiet audio playback should work: \(result.error ?? "")")
+    }
+
+    func testPlaybackWithSilence() throws {
+        // Pure silence WAV should still be playable (valid file)
+        let samples = generateSilence(duration: 1.0)
+        let url = tempDir.appendingPathComponent("silence_test.wav")
+        try writeWAV(samples: samples, to: url)
+
+        let result = testPlayback(url: url)
+        XCTAssertTrue(result.success, "Silence WAV should be playable: \(result.error ?? "")")
+    }
+
+    func testPlaybackMissingFile() {
+        let url = tempDir.appendingPathComponent("nonexistent.wav")
+        let result = testPlayback(url: url)
+        XCTAssertFalse(result.success, "Missing file should fail")
+        XCTAssertNotNil(result.error)
+    }
+
+    func testPlaybackLongRecording() throws {
+        // Simulate a 60s recording (like real use)
+        let samples = generateSineWave(frequency: 440, duration: 60.0, amplitude: 0.3)
+        let url = tempDir.appendingPathComponent("long_test.wav")
+        try writeWAV(samples: samples, to: url)
+
+        let result = testPlayback(url: url)
+        XCTAssertTrue(result.success, "60s recording playback should work: \(result.error ?? "")")
+    }
+
+    // MARK: - Real Recordings (if available)
+
+    func testPlaybackRealRecordings() throws {
+        let recordingsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Voca/recordings")
+
+        guard FileManager.default.fileExists(atPath: recordingsDir.path) else {
+            // No recordings dir = skip (not a failure)
+            print("Skipping: No Voca recordings directory found")
+            return
+        }
+
+        let files = try FileManager.default.contentsOfDirectory(at: recordingsDir, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "wav" }
+
+        guard !files.isEmpty else {
+            print("Skipping: No WAV files in recordings directory")
+            return
+        }
+
+        // Test the most recent recording
+        let sorted = files.sorted { $0.lastPathComponent > $1.lastPathComponent }
+        let latest = sorted[0]
+
+        let result = testPlayback(url: latest)
+        XCTAssertTrue(result.success, "Real recording playback failed for \(latest.lastPathComponent): \(result.error ?? "")")
+    }
+}

--- a/Tests/VocaTests/TextPostProcessingTests.swift
+++ b/Tests/VocaTests/TextPostProcessingTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import VocaTestable
+
+final class TextPostProcessingTests: XCTestCase {
+
+    func testFillerWordRemoval() {
+        // Test common filler words are removed
+        let input = "uh so um I think uhh this is uh working"
+        let result = postProcessText(input)
+        XCTAssertFalse(result.contains(" uh "), "Should remove 'uh'")
+        XCTAssertFalse(result.contains(" um "), "Should remove 'um'")
+        XCTAssertTrue(result.contains("think"), "Should keep real words")
+        XCTAssertTrue(result.contains("working"), "Should keep real words")
+    }
+
+    func testEmptyInput() {
+        XCTAssertEqual(postProcessText(""), "")
+    }
+
+    func testWhitespaceNormalization() {
+        let input = "hello   world"
+        let result = postProcessText(input)
+        XCTAssertFalse(result.contains("  "), "Should normalize double spaces")
+    }
+
+    func testCJKPunctuation() {
+        // Chinese text with mixed punctuation should be normalized
+        let input = "你好 , 世界"
+        let result = postProcessText(input)
+        // CJK text should not have spaces before/after punctuation
+        XCTAssertFalse(result.contains(" ,") || result.contains(", ") && result.contains("你"),
+            "CJK punctuation should be cleaned up")
+    }
+
+    func testPreservesNormalText() {
+        let input = "This is a normal sentence."
+        let result = postProcessText(input)
+        XCTAssertEqual(result.trimmed, input.trimmed, "Normal text should be preserved")
+    }
+
+    func testFillerAtStart() {
+        // "uh" at the start of a sentence should be removed
+        let input = "uh this is a test"
+        let result = postProcessText(input)
+        XCTAssertFalse(result.lowercased().hasPrefix("uh "), "Should remove leading filler word")
+        XCTAssertTrue(result.contains("test"), "Should keep real content")
+    }
+
+    func testMultipleFillerWords() {
+        let input = "um so uh I um think er this is ah good"
+        let result = postProcessText(input)
+        XCTAssertFalse(result.contains(" um "), "Should remove 'um'")
+        XCTAssertFalse(result.contains(" uh "), "Should remove 'uh'")
+        XCTAssertFalse(result.contains(" er "), "Should remove 'er'")
+        XCTAssertFalse(result.contains(" ah "), "Should remove 'ah'")
+        XCTAssertTrue(result.contains("think"), "Should keep real words")
+        XCTAssertTrue(result.contains("good"), "Should keep real words")
+    }
+
+    func testCapitalization() {
+        // First letter should be capitalized
+        let input = "hello world"
+        let result = postProcessText(input)
+        XCTAssertTrue(result.first?.isUppercase ?? false, "First letter should be capitalized")
+    }
+
+    func testSpaceBeforeComma() {
+        let input = "hello , world"
+        let result = postProcessText(input)
+        XCTAssertFalse(result.contains(" ,"), "Should remove space before comma")
+    }
+
+    func testChinesePunctuationNormalization() {
+        // Duplicate Chinese period should collapse to one
+        let input = "你好。。世界"
+        let result = postProcessText(input)
+        XCTAssertFalse(result.contains("。。"), "Duplicate Chinese periods should be normalized")
+    }
+}
+
+private extension String {
+    var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+}

--- a/Tests/VocaTests/VADTests.swift
+++ b/Tests/VocaTests/VADTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import VocaTestable
+
+final class VADTests: XCTestCase {
+
+    // MARK: - RMS Calculation
+
+    func testRMSSilence() {
+        let silence = [Float](repeating: 0, count: 1600)
+        XCTAssertEqual(calculateRMS(silence), 0)
+    }
+
+    func testRMSKnownSignal() {
+        // Constant signal of 0.5 should have RMS of 0.5
+        let signal = [Float](repeating: 0.5, count: 1000)
+        XCTAssertEqual(calculateRMS(signal), 0.5, accuracy: 0.001)
+    }
+
+    func testRMSEmpty() {
+        XCTAssertEqual(calculateRMS([]), 0)
+    }
+
+    // MARK: - VAD Segmentation
+
+    func testSilenceOnlyProducesNoSegments() {
+        let silence = generateSilence(duration: 5.0)
+        let segments = splitAudioByVAD(silence)
+        // Pure silence should produce no meaningful segments
+        // (may produce one if above minChunkSamples/2 threshold)
+        for segment in segments {
+            let rms = calculateRMS(segment.samples)
+            XCTAssertLessThan(rms, 0.02, "Silence-only input should not produce high-energy segments")
+        }
+    }
+
+    func testSingleSpeechSegment() {
+        // Speech (2s) + silence (2s)
+        let speech = generateSineWave(frequency: 440, duration: 2.0, amplitude: 0.3)
+        let silence = generateSilence(duration: 2.0)
+        let audio = concatenateAudio([speech, silence])
+
+        let segments = splitAudioByVAD(audio)
+        XCTAssertGreaterThanOrEqual(segments.count, 1, "Should detect at least one speech segment")
+    }
+
+    func testMultipleSpeechSegments() {
+        // speech(2s) + silence(1.5s) + speech(2s) + silence(1.5s)
+        let speech1 = generateSineWave(frequency: 440, duration: 2.0, amplitude: 0.3)
+        let silence1 = generateSilence(duration: 1.5)
+        let speech2 = generateSineWave(frequency: 880, duration: 2.0, amplitude: 0.3)
+        let silence2 = generateSilence(duration: 1.5)
+        let audio = concatenateAudio([speech1, silence1, speech2, silence2])
+
+        let segments = splitAudioByVAD(audio)
+        XCTAssertGreaterThanOrEqual(segments.count, 2, "Should detect two speech segments")
+    }
+
+    func testShortSpeechIgnored() {
+        // Very short speech (0.3s) should be ignored (below minChunkSamples)
+        let speech = generateSineWave(frequency: 440, duration: 0.3, amplitude: 0.3)
+        let silence = generateSilence(duration: 2.0)
+        let audio = concatenateAudio([speech, silence])
+
+        let segments = splitAudioByVAD(audio)
+        // Short speech below minimum should not produce standalone segments
+        for segment in segments {
+            // If a segment exists, it should be at least minChunkSamples/2
+            XCTAssertGreaterThanOrEqual(segment.samples.count, 8000, "Segments should meet minimum duration")
+        }
+    }
+
+    func testLongSpeechForceSplit() {
+        // 90 seconds of continuous speech should be force-split at 60s
+        let speech = generateSineWave(frequency: 440, duration: 90.0, amplitude: 0.3)
+        let segments = splitAudioByVAD(speech)
+        XCTAssertGreaterThanOrEqual(segments.count, 2, "90s speech should be split into at least 2 chunks")
+    }
+
+    // MARK: - VAD Config Variants
+
+    func testAggressiveVADMoreSegments() {
+        // Aggressive config (shorter silence threshold) should produce more segments
+        let speech1 = generateSineWave(frequency: 440, duration: 2.0, amplitude: 0.3)
+        let silence = generateSilence(duration: 0.5) // Short pause
+        let speech2 = generateSineWave(frequency: 880, duration: 2.0, amplitude: 0.3)
+        let trailing = generateSilence(duration: 2.0)
+        let audio = concatenateAudio([speech1, silence, speech2, trailing])
+
+        let defaultConfig = VADConfig() // 1.2s silence duration
+        let aggressiveConfig = VADConfig(silenceDuration: 0.3)
+
+        let defaultSegments = splitAudioByVAD(audio, config: defaultConfig)
+        let aggressiveSegments = splitAudioByVAD(audio, config: aggressiveConfig)
+
+        // Aggressive should find more segment boundaries
+        XCTAssertGreaterThanOrEqual(aggressiveSegments.count, defaultSegments.count,
+            "Aggressive VAD should produce >= segments than default")
+    }
+
+    func testHighThresholdIgnoresQuietSpeech() {
+        // Low amplitude speech should be treated as silence with high threshold
+        let quietSpeech = generateSineWave(frequency: 440, duration: 3.0, amplitude: 0.005)
+        let silence = generateSilence(duration: 2.0)
+        let audio = concatenateAudio([quietSpeech, silence])
+
+        let highThreshold = VADConfig(silenceThreshold: 0.05)
+        let segments = splitAudioByVAD(audio, config: highThreshold)
+
+        // With high threshold, quiet speech is treated as silence
+        for segment in segments {
+            let rms = calculateRMS(segment.samples)
+            XCTAssertLessThan(rms, 0.05, "High threshold should not detect quiet speech as voice")
+        }
+    }
+
+    // MARK: - VAD Parameter Comparison
+
+    func testConservativeVADFewerSegments() {
+        // Conservative config (longer silence duration) should produce fewer segments
+        let speech1 = generateSineWave(frequency: 300, duration: 2.0, amplitude: 0.2)
+        let pause = generateSilence(duration: 1.5)
+        let speech2 = generateSineWave(frequency: 400, duration: 2.0, amplitude: 0.2)
+        let trailing = generateSilence(duration: 2.0)
+        let audio = concatenateAudio([speech1, pause, speech2, trailing])
+
+        let conservativeConfig = VADConfig(silenceDuration: 2.0)
+        let segments = splitAudioByVAD(audio, config: conservativeConfig)
+
+        // 1.5s pause is shorter than 2.0s threshold, so conservative should NOT split there
+        XCTAssertLessThanOrEqual(segments.count, 2,
+            "Conservative VAD should not split on pauses shorter than its threshold")
+    }
+
+    func testSensitiveThresholdDetectsMoreSpeech() {
+        // Mix of loud and quiet speech - sensitive threshold should catch both
+        let loudSpeech = generateSineWave(frequency: 300, duration: 2.0, amplitude: 0.3)
+        let pause = generateSilence(duration: 1.5)
+        let quietSpeech = generateSineWave(frequency: 400, duration: 2.0, amplitude: 0.01)
+        let trailing = generateSilence(duration: 2.0)
+        let audio = concatenateAudio([loudSpeech, pause, quietSpeech, trailing])
+
+        let sensitiveConfig = VADConfig(silenceThreshold: 0.005)
+        let strictConfig = VADConfig(silenceThreshold: 0.05)
+
+        let sensitiveSegments = splitAudioByVAD(audio, config: sensitiveConfig)
+        let strictSegments = splitAudioByVAD(audio, config: strictConfig)
+
+        // Sensitive should detect quiet speech that strict misses
+        XCTAssertGreaterThanOrEqual(sensitiveSegments.count, strictSegments.count,
+            "Sensitive threshold should detect >= segments than strict")
+    }
+}

--- a/Voca/App/VoiceTranslatorApp.swift
+++ b/Voca/App/VoiceTranslatorApp.swift
@@ -482,7 +482,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func pasteFromHistory() {
-        if let text = historyManager.getNext() {
+        if let text = historyManager.nextItem() {
             pasteText(text)
         }
     }

--- a/Voca/Services/AudioRecorder.swift
+++ b/Voca/Services/AudioRecorder.swift
@@ -101,8 +101,10 @@ class AudioRecorder {
         audioFile = nil
         isRecording = false
 
-        // Process any remaining speech in buffer (call synchronously so it runs before completion)
-        if !sampleBuffer.isEmpty && sampleBuffer.count > Int(sampleRate * minSpeechDuration) {
+        // Flush any remaining speech in buffer (user explicitly stopped, so use a lower
+        // threshold than live VAD — don't drop short final phrases like "thank you")
+        let minFlushSamples = Int(sampleRate * 0.15)  // 150ms minimum for final flush
+        if sampleBuffer.count > minFlushSamples {
             let segment = sampleBuffer
             sampleBuffer = []
             print("📝 Flushing final segment: \(segment.count) samples")

--- a/Voca/Services/AudioRecorder.swift
+++ b/Voca/Services/AudioRecorder.swift
@@ -108,7 +108,9 @@ class AudioRecorder {
             let segment = sampleBuffer
             sampleBuffer = []
             print("📝 Flushing final segment: \(segment.count) samples")
-            onSpeechSegment?(segment)
+            DispatchQueue.main.async { [weak self] in
+                self?.onSpeechSegment?(segment)
+            }
         }
 
         print("Recording stopped")

--- a/Voca/Services/HistoryManager.swift
+++ b/Voca/Services/HistoryManager.swift
@@ -87,13 +87,64 @@ class HistoryManager {
             return
         }
 
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            print("Audio file not found: \(audioURL.path)")
+            return
+        }
+
         do {
             audioPlayer?.stop()
             audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
             audioPlayer?.play()
             print("Playing: \(audioURL.lastPathComponent)")
         } catch {
-            print("Failed to play audio: \(error)")
+            print("Direct playback failed: \(error), trying conversion...")
+            playWithConversion(audioURL)
+        }
+    }
+
+    private func playWithConversion(_ url: URL) {
+        do {
+            let audioFile = try AVAudioFile(forReading: url)
+            let format = audioFile.processingFormat
+            let frameCount = AVAudioFrameCount(audioFile.length)
+
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
+            try audioFile.read(into: buffer)
+
+            guard let int16Format = AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: format.sampleRate,
+                channels: format.channelCount,
+                interleaved: true
+            ) else { return }
+
+            guard let converter = AVAudioConverter(from: format, to: int16Format) else { return }
+            guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: int16Format, frameCapacity: frameCount) else { return }
+
+            var error: NSError?
+            converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+                outStatus.pointee = .haveData
+                return buffer
+            }
+
+            if let error = error {
+                print("Conversion failed: \(error)")
+                return
+            }
+
+            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("playback_\(UUID().uuidString).wav")
+            let outputFile = try AVAudioFile(forWriting: tempURL, settings: int16Format.settings)
+            try outputFile.write(from: outputBuffer)
+
+            audioPlayer = try AVAudioPlayer(contentsOf: tempURL)
+            audioPlayer?.play()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(frameCount) / format.sampleRate + 1.0) {
+                try? FileManager.default.removeItem(at: tempURL)
+            }
+        } catch {
+            print("Fallback playback failed: \(error)")
         }
     }
 

--- a/Voca/Services/HistoryManager.swift
+++ b/Voca/Services/HistoryManager.swift
@@ -7,13 +7,14 @@ struct HistoryItem {
     let timestamp: Date
 }
 
-class HistoryManager {
+class HistoryManager: NSObject, AVAudioPlayerDelegate {
     static let shared = HistoryManager()
 
     private var history: [HistoryItem] = []
     private var currentIndex: Int = -1
     private let maxItems = 10
     private var audioPlayer: AVAudioPlayer?
+    private var tempPlaybackURL: URL?
 
     // Directory for storing audio recordings
     private lazy var recordingsDir: URL = {
@@ -94,7 +95,9 @@ class HistoryManager {
 
         do {
             audioPlayer?.stop()
+            cleanupTempPlayback()
             audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
+            audioPlayer?.delegate = self
             audioPlayer?.play()
             print("Playing: \(audioURL.lastPathComponent)")
         } catch {
@@ -122,9 +125,15 @@ class HistoryManager {
             guard let converter = AVAudioConverter(from: format, to: int16Format) else { return }
             guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: int16Format, frameCapacity: frameCount) else { return }
 
+            var inputConsumed = false
             var error: NSError?
             converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+                if inputConsumed {
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
                 outStatus.pointee = .haveData
+                inputConsumed = true
                 return buffer
             }
 
@@ -137,14 +146,25 @@ class HistoryManager {
             let outputFile = try AVAudioFile(forWriting: tempURL, settings: int16Format.settings)
             try outputFile.write(from: outputBuffer)
 
+            tempPlaybackURL = tempURL
             audioPlayer = try AVAudioPlayer(contentsOf: tempURL)
+            audioPlayer?.delegate = self
             audioPlayer?.play()
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + Double(frameCount) / format.sampleRate + 1.0) {
-                try? FileManager.default.removeItem(at: tempURL)
-            }
         } catch {
             print("Fallback playback failed: \(error)")
+        }
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        cleanupTempPlayback()
+    }
+
+    private func cleanupTempPlayback() {
+        if let url = tempPlaybackURL {
+            try? FileManager.default.removeItem(at: url)
+            tempPlaybackURL = nil
         }
     }
 
@@ -152,6 +172,7 @@ class HistoryManager {
     func stopAudio() {
         audioPlayer?.stop()
         audioPlayer = nil
+        cleanupTempPlayback()
     }
 
     func clear() {

--- a/Voca/Services/HistoryManager.swift
+++ b/Voca/Services/HistoryManager.swift
@@ -25,9 +25,8 @@ class HistoryManager: NSObject, AVAudioPlayerDelegate {
     }()
 
     func add(_ text: String, audioURL: URL? = nil) {
-        var savedAudioURL: URL? = nil
+        var savedAudioURL: URL?
 
-        // Copy audio file to permanent storage if provided
         if let sourceURL = audioURL {
             let filename = "recording_\(Date().timeIntervalSince1970).wav"
             let destURL = recordingsDir.appendingPathComponent(filename)
@@ -42,67 +41,62 @@ class HistoryManager: NSObject, AVAudioPlayerDelegate {
 
         let item = HistoryItem(text: text, audioURL: savedAudioURL, timestamp: Date())
 
-        // Add to front, remove oldest if over limit
         history.insert(item, at: 0)
         if history.count > maxItems {
-            // Delete old audio file before removing
             if let oldAudioURL = history.last?.audioURL {
                 try? FileManager.default.removeItem(at: oldAudioURL)
             }
             history.removeLast()
         }
-        // Reset index for cycling
         currentIndex = -1
 
-        // Notify observers
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .historyDidUpdate, object: nil)
         }
     }
 
-    func getNext() -> String? {
+    func nextItem() -> String? {
         guard !history.isEmpty else { return nil }
 
         currentIndex = (currentIndex + 1) % history.count
         return history[currentIndex].text
     }
 
-    func getAll() -> [String] {
-        return history.map { $0.text }
-    }
+    var allItems: [HistoryItem] { history }
 
-    func getAllItems() -> [HistoryItem] {
-        return history
-    }
-
-    func getItem(at index: Int) -> HistoryItem? {
+    func item(at index: Int) -> HistoryItem? {
         guard index >= 0 && index < history.count else { return nil }
         return history[index]
     }
 
-    /// Play the audio recording for a history item
+    /// Play the audio recording for a history item by index
     func playAudio(at index: Int) {
-        guard let item = getItem(at: index),
+        guard let item = item(at: index),
               let audioURL = item.audioURL else {
-            print("No audio available for this item")
+            print("playAudio(at:): no audio for index \(index)")
+            return
+        }
+        playAudio(url: audioURL)
+    }
+
+    /// Play audio directly from a URL (preferred — avoids stale index issues)
+    func playAudio(url: URL) {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            print("playAudio(url:): file not found: \(url.path)")
             return
         }
 
-        guard FileManager.default.fileExists(atPath: audioURL.path) else {
-            print("Audio file not found: \(audioURL.path)")
-            return
-        }
+        audioPlayer?.delegate = nil
+        audioPlayer?.stop()
+        cleanupTempPlayback()
 
         do {
-            audioPlayer?.stop()
-            cleanupTempPlayback()
-            audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
+            audioPlayer = try AVAudioPlayer(contentsOf: url)
             audioPlayer?.delegate = self
             audioPlayer?.play()
-            print("Playing: \(audioURL.lastPathComponent)")
         } catch {
             print("Direct playback failed: \(error), trying conversion...")
-            playWithConversion(audioURL)
+            playWithConversion(url)
         }
     }
 
@@ -112,7 +106,10 @@ class HistoryManager: NSObject, AVAudioPlayerDelegate {
             let format = audioFile.processingFormat
             let frameCount = AVAudioFrameCount(audioFile.length)
 
-            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+                print("playWithConversion: failed to create input buffer")
+                return
+            }
             try audioFile.read(into: buffer)
 
             guard let int16Format = AVAudioFormat(
@@ -120,10 +117,19 @@ class HistoryManager: NSObject, AVAudioPlayerDelegate {
                 sampleRate: format.sampleRate,
                 channels: format.channelCount,
                 interleaved: true
-            ) else { return }
+            ) else {
+                print("playWithConversion: failed to create int16 format")
+                return
+            }
 
-            guard let converter = AVAudioConverter(from: format, to: int16Format) else { return }
-            guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: int16Format, frameCapacity: frameCount) else { return }
+            guard let converter = AVAudioConverter(from: format, to: int16Format) else {
+                print("playWithConversion: failed to create converter")
+                return
+            }
+            guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: int16Format, frameCapacity: frameCount) else {
+                print("playWithConversion: failed to create output buffer")
+                return
+            }
 
             var inputConsumed = false
             var error: NSError?
@@ -170,13 +176,14 @@ class HistoryManager: NSObject, AVAudioPlayerDelegate {
 
     /// Stop any currently playing audio
     func stopAudio() {
+        audioPlayer?.delegate = nil
         audioPlayer?.stop()
         audioPlayer = nil
         cleanupTempPlayback()
     }
 
     func clear() {
-        // Delete all audio files
+        stopAudio()
         for item in history {
             if let audioURL = item.audioURL {
                 try? FileManager.default.removeItem(at: audioURL)

--- a/Voca/Views/OnboardingWindowController.swift
+++ b/Voca/Views/OnboardingWindowController.swift
@@ -449,10 +449,11 @@ class OnboardingView: NSView {
     }
 
     @objc private func grantAccessibilityPermission() {
-        // Open System Settings directly without showing Apple's popup
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
-            NSWorkspace.shared.open(url)
-        }
+        // Use AXIsProcessTrustedWithOptions to trigger Apple's native prompt.
+        // This ensures the TCC entry matches the CURRENT binary's code signature,
+        // which matters after app updates that change the signature.
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        AXIsProcessTrustedWithOptions(options)
     }
 
     @objc private func refreshPermissions() {

--- a/Voca/Views/SettingsWindowController.swift
+++ b/Voca/Views/SettingsWindowController.swift
@@ -508,10 +508,11 @@ class SettingsView: NSView {
     }
 
     @objc private func openAccessibilitySettings() {
-        // Open System Settings directly without showing Apple's popup
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
-            NSWorkspace.shared.open(url)
-        }
+        // Use AXIsProcessTrustedWithOptions to trigger Apple's native prompt.
+        // This ensures the TCC entry matches the CURRENT binary's code signature,
+        // which matters after app updates that change the signature.
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        AXIsProcessTrustedWithOptions(options)
     }
 
     // MARK: - History

--- a/Voca/Views/SettingsWindowController.swift
+++ b/Voca/Views/SettingsWindowController.swift
@@ -521,7 +521,7 @@ class SettingsView: NSView {
         // Clear existing items
         historyStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
-        let items = historyManager.getAllItems()
+        let items = historyManager.allItems
 
         if items.isEmpty {
             let emptyLabel = NSTextField(labelWithString: NSLocalizedString("No transcriptions yet", comment: ""))

--- a/Voca/Views/StatusBarController.swift
+++ b/Voca/Views/StatusBarController.swift
@@ -262,6 +262,12 @@ class StatusBarController: NSObject {
         }
     }
 
+    @objc private func playHistoryAudio(_ sender: NSMenuItem) {
+        guard let dict = sender.representedObject as? [String: Any],
+              let index = dict["index"] as? Int else { return }
+        historyManager.playAudio(at: index)
+    }
+
     // MARK: - Update Checker
 
     @objc private func checkForUpdates() {
@@ -330,9 +336,10 @@ extension StatusBarController: NSMenuDelegate {
         menu.insertItem(header, at: insertIndex)
         insertIndex += 1
 
-        // Add history items - simple click to paste
+        // Add history items - with submenu for audio, simple click to paste otherwise
         for (i, historyItem) in historyItems.prefix(5).enumerated() {
             let preview = truncateToWidth(historyItem.text, maxWidth: 200)
+            let representedObject: [String: Any] = ["text": historyItem.text, "index": i]
 
             let item = NSMenuItem(
                 title: "  \(preview)",
@@ -340,8 +347,33 @@ extension StatusBarController: NSMenuDelegate {
                 keyEquivalent: ""
             )
             item.target = self
-            item.representedObject = historyItem.text
+            item.representedObject = representedObject
             item.tag = 201 + i
+
+            if historyItem.audioURL != nil {
+                let submenu = NSMenu()
+
+                let copyItem = NSMenuItem(
+                    title: NSLocalizedString("Copy to Clipboard", comment: ""),
+                    action: #selector(historyItemClicked(_:)),
+                    keyEquivalent: ""
+                )
+                copyItem.target = self
+                copyItem.representedObject = representedObject
+
+                let playItem = NSMenuItem(
+                    title: NSLocalizedString("Play Audio", comment: ""),
+                    action: #selector(playHistoryAudio(_:)),
+                    keyEquivalent: ""
+                )
+                playItem.target = self
+                playItem.representedObject = representedObject
+
+                submenu.addItem(copyItem)
+                submenu.addItem(playItem)
+                item.submenu = submenu
+                item.action = nil  // parent item opens submenu, not pastes
+            }
 
             menu.insertItem(item, at: insertIndex)
             insertIndex += 1

--- a/Voca/Views/StatusBarController.swift
+++ b/Voca/Views/StatusBarController.swift
@@ -222,16 +222,8 @@ class StatusBarController: NSObject {
     }
 
     @objc private func historyItemClicked(_ sender: NSMenuItem) {
-        // Handle both old format (string) and new format (dictionary)
-        let text: String
-        if let dict = sender.representedObject as? [String: Any],
-           let t = dict["text"] as? String {
-            text = t
-        } else if let t = sender.representedObject as? String {
-            text = t
-        } else {
-            return
-        }
+        guard let dict = sender.representedObject as? [String: Any],
+              let text = dict["text"] as? String else { return }
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -264,8 +256,32 @@ class StatusBarController: NSObject {
 
     @objc private func playHistoryAudio(_ sender: NSMenuItem) {
         guard let dict = sender.representedObject as? [String: Any],
-              let index = dict["index"] as? Int else { return }
-        historyManager.playAudio(at: index)
+              let audioURL = dict["audioURL"] as? URL else { return }
+        historyManager.playAudio(url: audioURL)
+    }
+
+    private func makeAudioSubmenu(representedObject: [String: Any]) -> NSMenu {
+        let submenu = NSMenu()
+
+        let copyItem = NSMenuItem(
+            title: NSLocalizedString("Copy to Clipboard", comment: ""),
+            action: #selector(historyItemClicked(_:)),
+            keyEquivalent: ""
+        )
+        copyItem.target = self
+        copyItem.representedObject = representedObject
+
+        let playItem = NSMenuItem(
+            title: NSLocalizedString("Play Audio", comment: ""),
+            action: #selector(playHistoryAudio(_:)),
+            keyEquivalent: ""
+        )
+        playItem.target = self
+        playItem.representedObject = representedObject
+
+        submenu.addItem(copyItem)
+        submenu.addItem(playItem)
+        return submenu
     }
 
     // MARK: - Update Checker
@@ -312,18 +328,14 @@ extension StatusBarController: NSMenuDelegate {
         // Update hint text in case shortcut changed
         updateHintText()
 
-        // Remove old history items (tags 201+)
+        // Remove old history items (tags 201–210) and header (tag 204)
         for tag in 201...210 {
             while let item = menu.item(withTag: tag) {
                 menu.removeItem(item)
             }
         }
-        while let item = menu.item(withTag: 204) {  // Header
-            menu.removeItem(item)
-        }
 
-        // Get history items
-        let historyItems = historyManager.getAllItems()
+        let historyItems = historyManager.allItems
 
         // Find insertion point (after separator with tag 200)
         guard let separatorIndex = menu.items.firstIndex(where: { $0.tag == 200 }) else { return }
@@ -339,7 +351,10 @@ extension StatusBarController: NSMenuDelegate {
         // Add history items - with submenu for audio, simple click to paste otherwise
         for (i, historyItem) in historyItems.prefix(5).enumerated() {
             let preview = truncateToWidth(historyItem.text, maxWidth: 200)
-            let representedObject: [String: Any] = ["text": historyItem.text, "index": i]
+            var representedObject: [String: Any] = ["text": historyItem.text]
+            if let audioURL = historyItem.audioURL {
+                representedObject["audioURL"] = audioURL
+            }
 
             let item = NSMenuItem(
                 title: "  \(preview)",
@@ -351,28 +366,8 @@ extension StatusBarController: NSMenuDelegate {
             item.tag = 201 + i
 
             if historyItem.audioURL != nil {
-                let submenu = NSMenu()
-
-                let copyItem = NSMenuItem(
-                    title: NSLocalizedString("Copy to Clipboard", comment: ""),
-                    action: #selector(historyItemClicked(_:)),
-                    keyEquivalent: ""
-                )
-                copyItem.target = self
-                copyItem.representedObject = representedObject
-
-                let playItem = NSMenuItem(
-                    title: NSLocalizedString("Play Audio", comment: ""),
-                    action: #selector(playHistoryAudio(_:)),
-                    keyEquivalent: ""
-                )
-                playItem.target = self
-                playItem.representedObject = representedObject
-
-                submenu.addItem(copyItem)
-                submenu.addItem(playItem)
-                item.submenu = submenu
-                item.action = nil  // parent item opens submenu, not pastes
+                item.submenu = makeAudioSubmenu(representedObject: representedObject)
+                item.action = nil
             }
 
             menu.insertItem(item, at: insertIndex)

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,18 @@
     <description>Voice-to-text transcription for macOS</description>
     <language>en</language>
     <item>
+      <title>Version 1.2.8</title>
+      <pubDate>Sun, 22 Feb 2026 09:50:33 +0000</pubDate>
+      <sparkle:version>102</sparkle:version>
+      <sparkle:shortVersionString>1.2.8</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/zhengyishen0/voca-app/releases/download/v1.2.8/Voca-1.2.8.dmg"
+        sparkle:edSignature="jfT/kgiNmHoXxOtQyy4bQxY0Kgjl6HINckLW6NPtRL0Y8cm/HZvajaxkBQb8N24iSUOY05+InbDdzSpr0G5nDQ=="
+        length="17581807"
+        type="application/octet-stream"/>
+    </item>
+    <item>
       <title>Version 1.2.7</title>
       <pubDate>Mon, 19 Jan 2026 15:28:29 +0000</pubDate>
       <sparkle:version>97</sparkle:version>

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,18 @@
     <description>Voice-to-text transcription for macOS</description>
     <language>en</language>
     <item>
+      <title>Version 1.2.9</title>
+      <pubDate>Sun, 22 Feb 2026 10:33:25 +0000</pubDate>
+      <sparkle:version>106</sparkle:version>
+      <sparkle:shortVersionString>1.2.9</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/zhengyishen0/voca-app/releases/download/v1.2.9/Voca-1.2.9.dmg"
+        sparkle:edSignature="8Ic8og+qzBP8tJJexbk1rXfB1cUmo/+7j7O1NxI4OTxmAOwp5U5WDiVHuI6oTF3peTR19yFLc1EazaKSTM2aBA=="
+        length="17582367"
+        type="application/octet-stream"/>
+    </item>
+    <item>
       <title>Version 1.2.8</title>
       <pubDate>Sun, 22 Feb 2026 09:50:33 +0000</pubDate>
       <sparkle:version>102</sparkle:version>


### PR DESCRIPTION
## Summary
- Fix history audio playback that was triggering TCC microphone permission checks
- Add Play Audio submenu for history items with recordings
- Add robust Float32→Int16 conversion fallback for non-standard WAV formats
- Fix stale-index bug by embedding audioURL directly in menu item
- Add delegate lifecycle cleanup to prevent callbacks on deallocated objects
- Add SPM test infrastructure (VocaTestable + VocaTests)

## Test plan
- [x] Build succeeds: `xcodebuild build`
- [x] Manual test: record → play from history menu → audio plays correctly
- [x] No TCC permission popup when playing audio

🤖 Generated with [Claude Code](https://claude.ai/code)